### PR TITLE
Updated submodule to anonymously accessible https github repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "technical_information/network_specifications/theme"]
 	path = technical_information/network_specifications/theme
-	url = git@github.com:KtorZ/YetiDisqus.git
+	url = https://github.com/KtorZ/YetiDisqus


### PR DESCRIPTION
For machines that didn't have their ssh keys linked to GH the git@github.com url caused:
> Permission denied (publickey).
> fatal: Could not read from remote repository.

> Please make sure you have the correct access rights
> and the repository exists.
> Clone of 'git@github.com:KtorZ/YetiDisqus.git' into submodule path 'technical_information/network_specifications/theme' failed
