### PR TITLE
Document use of v1.acccount.thethingsnetwork.org

### DIFF
--- a/_content/network/cli-v1/configuration.md
+++ b/_content/network/cli-v1/configuration.md
@@ -20,6 +20,21 @@ export TTNCTL_TTN_HANDLER=localhost:1782
 export TTNCTL_TTN_ACCOUNT_SERVER=https://account.thethingsnetwork.org
 ```
 
+As of December 2016, the default production environment is active, and it's not compatible; so the default for `TTNCTL_TTN_ACCOUNT_SERVER` shown above, which is compiled into `ttnctl`, **is incorrect**. You must add the following to your environment in order to work with the legacy staging environment. This must be before launching `ttnctl`.
+
+```sh
+export TTNCTL_TTN_ACCOUNT_SERVER=https://v1.account.thethingsnetwork.org
+```
+
+Failure to do this will result in the following error when you try to log in:
+
+```sh
+% ./ttnctl user login user@example.com
+Password:
+  INFO Visit https://account.thethingsnetwork.org to register or to retrieve your account credentials.
+ FATAL Failed to login                          error=Grant type is not available for the client
+```
+
 ## Configuration File
 
 A configuration file can be specified using the `--config` option. By default, `ttnctl` looks for the file `~/.ttnctl.yaml` (in your home directory).


### PR DESCRIPTION
During the transition, it is useful to document exactly how to use the v1 ttnctl app..