### PR TITLE
Change naming scheme of packet forwarder

### DIFF
--- a/_content/gateways/registration.md
+++ b/_content/gateways/registration.md
@@ -4,14 +4,16 @@ title: Gateway Registration
 
 # Gateway Registration
 
-We are transitioning to a new way to register and manage your gateways. Please read this guide carefully to understand how it currently works and what will change.
+The are mainly two types of packet forwarders that can be running on your gateway, namely [TTN Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) (formerly known as the Gateway Connector) or [UDP Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/legacy) (also known as the Semtech Packet Forwarder or Poly Packet Forwarder). 
 
-> At the moment, most gateways don't support the Gateway Connector protocol yet. Follow the steps for connecting using the [Via Packet Forwarder](#via-packet-forwarder).
+Please read this guide carefully to understand how to register your gateway with The Things Network.
 
-## Via Gateway Connector
-This is a work in process. The Things Gateway will be the first gateway to use this new protocol. Firmware and guides for other gateways will need to be updated.
+> If you have an off-the-shelf gateway with the default software, it most likely uses the UDP Packet Forwarder. Follow the steps for connecting using the [UDP Packet Forwarder](#via-udp-packet-forwarder).
 
-> Make sure your gateway supports [The Things Network Gateway Connector](https://github.com/TheThingsNetwork/ttn-gateway-connector) before you continue.
+## Via TTN Packet Forwarder
+The Things Gateway uses this packet forwarder and we also have support for Kerlink, Multitech and other Linux based gateways. This is the preferred packet forwarder to use with The Things Network. Firmware and guides for other gateways will need to be updated.
+
+> Make sure your gateway runs [The Things Network Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) before you continue.
 
 ### Start with Registration
 You start by [registering your gateway](https://console.thethingsnetwork.org/gateways/register) in the Console.
@@ -19,8 +21,8 @@ You start by [registering your gateway](https://console.thethingsnetwork.org/gat
 ![Registration for Gateway Connector](registration-connector.png)
 
 - For **Protocol**, leave **gateway connector** selected.
-- For **Gateway ID**, choose a unique ID of lower case, alphanumeric characters and nonconsecutive `-` and `_`.
-- Select the frequency plan (determined by your region) the gateway uses.
+- For **Gateway ID**, choose a unique ID of lower case, alphanumeric characters and nonconsecutive `-` and `_`. **DO NOT** use an EUI.
+- Select the frequency plan ([determined by your region](https://www.thethingsnetwork.org/wiki/LoRaWAN/Frequencies/By-Country)) the gateway uses.
 - Click to drop the pin at the exact location (pan and zoom in before you drop).
 - Click **Register Gateway** to finish.
 
@@ -28,23 +30,23 @@ You start by [registering your gateway](https://console.thethingsnetwork.org/gat
 
 > After registering the gateway, select **Settings** from the top right menu on the Gateway screen so set the gateway description, location altitude, privacy settings and other information.
 
-### Configure with new Gateway Connector
+### Configure gateway with TTN Packet Forwarder
 You then configure the gateway with the ID and Key from the registration. This allows you to manage most of the gateway's configuration from the Console.
 
 > If your gateway does not have a GPS module we advise you not to configure a manual location in the gateway. Do this in the Console instead so that you can change it without accessing the gateway.
 
-### Untrusted & Unmanaged Gateways
-If you don't register your gateway or use the key to activate it, The Things Network will still accept the packages, but mark them as **untrusted**. The gateway will appear on the [map](https://www.thethingsnetwork.org/map) as **Unregistered** or **Unactivated**. If it is unregistered you will not be able to manage its configuration (e.g. location) form the Console.
-
-## Via Packet Forwarder
+## Via UDP Packet Forwarder
+The UDP Packet Forwarder is deprecated, but will still be supported by TTN. We advise you to upgrade to the TTN Packet Forwarder.
 
 ### Start with Configuration
-Following your gateway's guide, you start by configuring your gateway to forward packages to The Things Network, likely using [our fork of the Semtech Lora network packet forwarder](https://github.com/TheThingsNetwork/packet_forwarder). The guide should also help you set or retrieve the gateway's EUI, likely the Mac address of the LoRa module which looks like `B827EBFFFE87BD11`.
+Follow your gateway's manual to configure it to forward packets to The Things Network. Configure it to forward to the correct [router address](https://www.thethingsnetwork.org/wiki/Backend/Connect/Gateway#connect-a-gateway_server-addresses) for [your region](https://www.thethingsnetwork.org/wiki/LoRaWAN/Frequencies/By-Country). The guide should also help you set or retrieve the gateway's EUI, likely the MAC address of the LoRa module which looks like `B827EBFFFE87BD11`.
+
+You will likely also need the `global_conf.json` file for the frequency plan used in your region. You can find it on [our github repo](https://github.com/TheThingsNetwork/gateway-conf).
 
 > If your gateway does not have a GPS module we advise you not to configure a manual location in the gateway. Do this in the Console instead so that you can change it without accessing the gateway.
 
 ### Packet Forwarder Bridge
-We have a special bridge in place that will continue to accept packages from gateways that don't use the new Gateway Connector. It will lowercase the EUI and prefix it with `eui-`. So a gateway with EUI `B827EBFFFE87BD11` will appear in meta data and APIs as `eui-b827ebfffe87bd11`.
+We have a special bridge in place that will continue to accept packages from gateways using the UDP Packet Forwarder. It will lowercase the EUI and prefix it with `eui-`. So a gateway with EUI `B827EBFFFE87BD11` will appear in meta data and APIs as `eui-b827ebfffe87bd11`.
 
 ### Register 
 [Register your gateway](https://console.thethingsnetwork.org/gateways/register) via the console. This will link it to your account so that you can manage it.
@@ -53,13 +55,15 @@ We have a special bridge in place that will continue to accept packages from gat
 
 - For **Protocol**, select **packet forwarder**.
 - For **Gateway EUI**, paste your gateway's EUI (8 bytes).
-- Select the frequency plan (determined by your region) the gateway uses.
+- Select the frequency plan ([determined by your region](https://www.thethingsnetwork.org/wiki/LoRaWAN/Frequencies/By-Country)) the gateway uses.
 - Click to drop the pin at the exact location (pan and zoom in before you drop).
 
 > After registering the gateway, select **Settings** from the top right menu on the Gateway screen so set the gateway description, location altitude, privacy settings and other information.
 
 ### Unregistered Gateways
-If you don't register your gateway, The Things Network will still accept messages it forwards, but mark them as **untrusted**. The gateway will appear on the [map](https://www.thethingsnetwork.org/map) as **Unregistered**. You will not be able to manage its configuration (e.g. location) from the Console.
+If you don't register your gateway, The Things Network will still accept packets it forwards, but mark them as **untrusted**. The gateway will appear on the [map](https://www.thethingsnetwork.org/map) as **Unregistered**. You will not be able to manage its configuration (e.g. location) from the Console.
+
+
 
 ## Troubleshooting & FAQ
 
@@ -68,7 +72,7 @@ If you return to the Gateways screen without seeing the newly registered gateway
 
 ![Registration Error](registration-error.png)
 
-This means someone else already registered this Gateway ID or EUI. If you registered to use the gateway connector, simply think of a new ID. If you registered to use the packet forwarder, check the manual of your gateway to see if you can configure it with a [different (random) EUI](https://www.randomlists.com/string?length=16).
+This means someone else already registered this Gateway ID or EUI. If you registered to use TTN Packet Forwarder, simply think of a new ID. If you registered to use the UDP Packet Forwarder, check the manual of your gateway to see if you can configure it with a [different (random) EUI](https://www.randomlists.com/string?length=16).
 
-### How can I switch from the packet forwarder protocol to the gateway connector protocol?
-You can't. Once the Gateway Connector is available for your gateway, you will need to reconfigure it as a new gateway and delete the old registration.
+### How can I switch from the UDP Packet Forwarder to TTN Packet Forwarder?
+You just need to install [TTN Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) on your gateway and configure it with the gateway ID and Key as listed on the console.

--- a/_content/gateways/registration.md
+++ b/_content/gateways/registration.md
@@ -4,16 +4,14 @@ title: Gateway Registration
 
 # Gateway Registration
 
-The are mainly two types of packet forwarders that can be running on your gateway, namely [TTN Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) (formerly known as the Gateway Connector) or [UDP Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/legacy) (also known as the Semtech Packet Forwarder or Poly Packet Forwarder). 
+There are mainly two types of packet forwarders that can be running on your gateway, namely [TTN Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) or [UDP Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/legacy) (also known as the Semtech Packet Forwarder or Poly Packet Forwarder). 
 
 Please read this guide carefully to understand how to register your gateway with The Things Network.
 
 > If you have an off-the-shelf gateway with the default software, it most likely uses the UDP Packet Forwarder. Follow the steps for connecting using the [UDP Packet Forwarder](#via-udp-packet-forwarder).
 
 ## Via TTN Packet Forwarder
-The Things Gateway uses this packet forwarder and we also have support for Kerlink, Multitech and other Linux based gateways. This is the preferred packet forwarder to use with The Things Network. Firmware and guides for other gateways will need to be updated.
-
-> Make sure your gateway runs [The Things Network Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) before you continue.
+The Things Network Packet Forwarder uses an authenticated and encrypted TCP connection to our network server and has support for Kerlink, Multitech and other Linux based gateways. This is the preferred packet forwarder to use with The Things Network.
 
 ### Start with Registration
 You start by [registering your gateway](https://console.thethingsnetwork.org/gateways/register) in the Console.
@@ -21,7 +19,7 @@ You start by [registering your gateway](https://console.thethingsnetwork.org/gat
 ![Registration for Gateway Connector](registration-connector.png)
 
 - For **Protocol**, leave **gateway connector** selected.
-- For **Gateway ID**, choose a unique ID of lower case, alphanumeric characters and nonconsecutive `-` and `_`. **DO NOT** use an EUI.
+- For **Gateway ID**, choose a unique ID of lower case, alphanumeric characters and nonconsecutive `-` and `_`.
 - Select the frequency plan ([determined by your region](https://www.thethingsnetwork.org/wiki/LoRaWAN/Frequencies/By-Country)) the gateway uses.
 - Click to drop the pin at the exact location (pan and zoom in before you drop).
 - Click **Register Gateway** to finish.
@@ -31,7 +29,9 @@ You start by [registering your gateway](https://console.thethingsnetwork.org/gat
 > After registering the gateway, select **Settings** from the top right menu on the Gateway screen so set the gateway description, location altitude, privacy settings and other information.
 
 ### Configure gateway with TTN Packet Forwarder
-You then configure the gateway with the ID and Key from the registration. This allows you to manage most of the gateway's configuration from the Console.
+
+
+Make sure your gateway runs [The Things Network Packet Forwarder](https://github.com/TheThingsNetwork/packet_forwarder/tree/master) before you continue. Then configure it with the ID and Key from the registration on the console. This allows you to manage most of the gateway's configuration from the Console, without having to log on to the gateway.
 
 > If your gateway does not have a GPS module we advise you not to configure a manual location in the gateway. Do this in the Console instead so that you can change it without accessing the gateway.
 


### PR DESCRIPTION
Preliminary changes for new and preferred TTN Packet Forwarder. More rewriting to come and will be committed to this branch.