### PR TITLE
Load ionicons in HTTPS

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -8,7 +8,7 @@ $baseurl: {{ site.baseurl }};
 // Fonts
 @import 'https://fonts.googleapis.com/css?family=Lato:400,400i,700,700i';
 @import 'https://cdn.jsdelivr.net/font-hack/2.020/css/hack-extended.min.css';
-@import 'http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css';
+@import 'https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css';
 
 @import '../node_modules/stylebook/dist/scss/ttn/bootstrap-variables';
 


### PR DESCRIPTION
Fix error:

```
Mixed Content: The page at ‘https://www.thethingsnetwork.org/docs/devices/arduino/' was loaded over HTTPS, but requested an insecure stylesheet ‘http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css’. This request has been blocked; the content must be served over HTTPS.
```