### PR TITLE
link error line 20

### DIFF
--- a/_content/gateways/packet-forwarder/ttn.md
+++ b/_content/gateways/packet-forwarder/ttn.md
@@ -18,16 +18,6 @@ The TTN Packet Forwarder is a new packet forwarder, developed by the Things Netw
 
 Currently, we have installation guides available to install the packet forwarder for [Multitech Conduit](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/MULTITECH.md), [Kerlink IoT Station](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/KERLINK.md) and [Raspberry Pi + iC880a](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/IMST_RPI.md) setups.
 
-https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/IMST_RPI.md
-
-
-
-
-
-
-
-
-
 We will be adding more gateways over time. In the meantime, if you have a different gateway, we have documentation available to help you [build the packet forwarder](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/SPI.md) for your own gateway. The TTN Packet Forwarder being open-source, please feel free to contribute with new documentation!
 
 ## Configuration

--- a/_content/gateways/packet-forwarder/ttn.md
+++ b/_content/gateways/packet-forwarder/ttn.md
@@ -16,7 +16,7 @@ The TTN Packet Forwarder is a new packet forwarder, developed by the Things Netw
 
 ## Installation
 
-Currently, we have installation guides available to install the packet forwarder for [Multitech Conduit](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/MULTITECH.md), [Kerlink IoT Station](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/KERLINK.md) and [Raspberry Pi + iC880a](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/KERLINK.md) setups.
+Currently, we have installation guides available to install the packet forwarder for [Multitech Conduit](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/MULTITECH.md), [Kerlink IoT Station](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/KERLINK.md) and [Raspberry Pi + iC880a](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/IMST_RPI.md) setups.
 
 https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/IMST_RPI.md
 

--- a/_content/gateways/packet-forwarder/ttn.md
+++ b/_content/gateways/packet-forwarder/ttn.md
@@ -18,6 +18,16 @@ The TTN Packet Forwarder is a new packet forwarder, developed by the Things Netw
 
 Currently, we have installation guides available to install the packet forwarder for [Multitech Conduit](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/MULTITECH.md), [Kerlink IoT Station](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/KERLINK.md) and [Raspberry Pi + iC880a](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/KERLINK.md) setups.
 
+https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/IMST_RPI.md
+
+
+
+
+
+
+
+
+
 We will be adding more gateways over time. In the meantime, if you have a different gateway, we have documentation available to help you [build the packet forwarder](https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/SPI.md) for your own gateway. The TTN Packet Forwarder being open-source, please feel free to contribute with new documentation!
 
 ## Configuration


### PR DESCRIPTION
https://www.thethingsnetwork.org/docs/gateways/packet-forwarder/ttn.html


the  link to the 880 installation goes to the kerlink installation and not to where it should go here:-    https://github.com/TheThingsNetwork/packet_forwarder/blob/master/docs/INSTALL_INSTRUCTIONS/IMST_RPI.md.