### PR TITLE
Update troubleshooting.md

### DIFF
--- a/_content/devices/node/troubleshooting.md
+++ b/_content/devices/node/troubleshooting.md
@@ -12,7 +12,7 @@ Since Mac OS El Capitan, there have been [many reports](https://www.google.com/s
 
 ## Serial Port shows up, but uploading code fails (Linux)
 
-Try the [steps documented on the Arduino Website](http://www.arduino.org/learning/getting-started/arduino-ide-on-linux-based-os). Normally the problem is another program also trying to access the serial port. **modemmanager** and **usb_modeswitch** are common culprits of this.
+Try the [steps documented on the Arduino Website](https://www.arduino.cc/en/Guide/Linux#toc6). Normally the problem is another program also trying to access the serial port. **modemmanager** and **usb_modeswitch** are common culprits of this.
 
 
 


### PR DESCRIPTION
I found an outdated link at https://www.thethingsnetwork.org/docs/devices/node/troubleshooting.html to http://www.arduino.org/learning/getting-started/arduino-ide-on-linux-based-os . The new correct link is https://www.arduino.cc/en/Guide/Linux#toc6