### PR TITLE
Update quick-start.md

### DIFF
--- a/_content/devices/node/quick-start.md
+++ b/_content/devices/node/quick-start.md
@@ -151,7 +151,7 @@ As you can see, the example sends all sensor data from the `interval()` callback
 ## Monitor & Decode Messages
 Let's see the messages come in.
 
-1.  From the application's screen in the console, select **Data** from the top right menu.
+1.  Since we are in the device overview we need to return to the application's screen in the console. On the top left breadcrumb click on your application name. Select **Data** from the top right menu.
 
     You should now see the messages come in. If you don't see anything you likely do not have network coverage at your location.
 

--- a/_content/devices/node/quick-start.md
+++ b/_content/devices/node/quick-start.md
@@ -151,7 +151,7 @@ As you can see, the example sends all sensor data from the `interval()` callback
 ## Monitor & Decode Messages
 Let's see the messages come in.
 
-1.  Since we are in the device overview we need to return to the application's screen in the console. On the top left breadcrumb click on your application name. Select **Data** from the top right menu.
+1.  Since we are in the device overview, we need to return to the application's screen in the console. On the top left breadcrumb, click on your application name. Select **Data** from the top right menu.
 
     You should now see the messages come in. If you don't see anything you likely do not have network coverage at your location.
 


### PR DESCRIPTION
As a first time user of this manual I was looking for the 'Payload Formats' menu item for a while and was not able to find it, while other buttons such as 'data' were available. Then I found out that in the step before at the 'Example Code', it is another screen (device) then the application screen, and that the device is not having a payload menu item. It was unclear to me by the current documentation that I have to return on a higher level of the application screen. I hope I made it more clear and less confusing for new users by this update.