### PR TITLE
Bug Fix, incorrect LED state after disconnect with LED = On

### DIFF
--- a/_content/devices/uno/quick-start.md
+++ b/_content/devices/uno/quick-start.md
@@ -77,8 +77,8 @@ Let's program your device with a so-called sketch.
       loraSerial.begin(57600);
       debugSerial.begin(9600);
       
-      // Initialise LED output pin
-      pinMode(LED_BUILTIN,OUTPUT);
+      // Initialize LED output pin
+      pinMode(LED_BUILTIN, OUTPUT);
     
       // Wait a maximum of 10s for Serial Monitor
       while (!debugSerial && millis() < 10000);

--- a/_content/devices/uno/quick-start.md
+++ b/_content/devices/uno/quick-start.md
@@ -76,6 +76,9 @@ Let's program your device with a so-called sketch.
     void setup() {
       loraSerial.begin(57600);
       debugSerial.begin(9600);
+      
+      // Initialise LED output pin
+      pinMode(LED_BUILTIN,OUTPUT);
     
       // Wait a maximum of 10s for Serial Monitor
       while (!debugSerial && millis() < 10000);


### PR DESCRIPTION
I found a bug that occurs when you disconnect the things uno board from USB power supply when the LED is in on state.
When you reconnect the board the LED state starts in off state but the LoRa payloads return LED = On.  I think this is due to the pin not being correctly initialised as an output and so the digital read is reading a floating voltage on an input pin.
Adding the pinMode command in setup seemed to resolve this issue for me.