### PR TITLE
Update frequencies-by-country.md

### DIFF
--- a/_content/lorawan/frequencies-by-country.md
+++ b/_content/lorawan/frequencies-by-country.md
@@ -139,7 +139,7 @@ For discussions about the frequency plans in different countries, see the posts 
 | Iran | | EN 302 208 |
 | Iraq
 | Ireland | EU863-870<br />EU433 | CEPT Rec. 70-03 |
-| Israel | | EN 302 208 |
+| Israel | ISR915-917mhz  />EU433 | https://www.gov.il/he/Departments/news/iot27102017|
 | Italy | EU863-870<br />EU433 | CEPT Rec. 70-03 |
 
 ### J


### PR DESCRIPTION
Update the frequency  with 915-917  to be in line  with LoRaWAN™ Regional Parameters v1.1rB  

Note they only  stated 915-917   25mw  power and 100mw  at 916.3  
 I took 915.1 to  916.9 with a 300khz between channels and called it isr915-917 ( no legal document)