### PR TITLE
Update frequencies-by-country.md

### DIFF
--- a/_content/lorawan/frequencies-by-country.md
+++ b/_content/lorawan/frequencies-by-country.md
@@ -61,7 +61,7 @@ For discussions about the frequency plans in different countries, see the posts 
 | Canada | US902-928 | |
 | Central African Republic (CAR)
 | Chad
-| Chile | US902-928 | |
+| Chile | AU915-928 | [FIJA NORMA TECNICA DE EQUIPOS DE ALCANCE REDUCIDO](https://www.leychile.cl/Consulta/m/norma_plana?org=&idNorma=240404) |
 | China | CN470-510<br />CN779-787 | |
 | Colombia | US902-928 | |
 | Comoros


### PR DESCRIPTION
Chilean mobile carrier Entel has spectrum rights in the lower 900 MHz range, including 902.1-912.1 MHz. As a result, the Chilean government doesn't permit non-cellular devices to emit more than 7 mW of power. The range from 915-928 allows up to 100 mW power. For this reason, TTN in Chile should use the AU/NZ 915 MHz band plan.