### PR TITLE
How to fix reboot loop

### DIFF
--- a/_content/gateways/gateway/faq.md
+++ b/_content/gateways/gateway/faq.md
@@ -82,6 +82,7 @@ When connected to the same network, some information can be seen at http://thing
 
 #### Q. My gateway is in a reboot loop. How can I fix it?
 
-- Symptom: After booting the gateway, 2 LEDs are on and the 3rd LED is blinking. After ~1 minute without progress, the gateway suddenly reboots and the whole thing repeats...
-- Possible cause: The LoRa board is not fully pushed in in the connector. 
-- Fix: Open the lid and push the LoRa board in the connector. See also: https://github.com/TheThingsProducts/gateway/issues/1#issuecomment-405523207
+- Symptom: After booting the gateway, 2 LEDs are on and the 3rd LED is blinking. After ~1 minute without progress, the gateway suddenly reboots and the whole thing repeats.
+- Possible cause: The LoRa board is not fully pushed in in the socket. 
+- Fix: Open the lid and push the LoRa board in the socket. See also: https://github.com/TheThingsProducts/gateway/issues/1#issuecomment-405523207
+- Remark: If this fix does not work for you, the right place to look for other solutions is: https://github.com/TheThingsProducts/gateway/issues

--- a/_content/gateways/gateway/faq.md
+++ b/_content/gateways/gateway/faq.md
@@ -79,3 +79,9 @@ Connect to the gateways WiFi access point ``Things-Gateway-XXXX`` using the pass
 To check the status of the gateway, go to the console as directed afterwards in the activation process. Under the gateway section (https://console.thethingsnetwork.org/gateways), you can see the status. If any device sends data through your gateway, you can check it under the ‘traffic’ section.
 
 When connected to the same network, some information can be seen at http://things-gateway.local/info.
+
+#### Q. My gateway is in a reboot loop. How can I fix it?
+
+- Symptom: After booting the gateway, 2 LEDs are on and the 3rd LED is blinking. After ~1 minute without progress, the gateway suddenly reboots and the whole thing repeats...
+- Possible cause: The LoRa board is not fully pushed in in the connector. 
+- Fix: Open the lid and push the LoRa board in the connector. See also: https://github.com/TheThingsProducts/gateway/issues/1#issuecomment-405523207


### PR DESCRIPTION
It seems (by searching in the Forum) that several people were affected by this issue that renders the gateway useless. Unfortunatelly there is no information on the regular webpage, how this could be fixed. What I describe here, did definitely fix my endless reboot loop.