### PR TITLE
Updating to new Swiss zone domain

### DIFF
--- a/_content/gateways/packet-forwarder/semtech-udp.md
+++ b/_content/gateways/packet-forwarder/semtech-udp.md
@@ -64,7 +64,7 @@ Unless you're running the network yourself on specific ports, the **ports** will
 | `router.jp.thethings.network`       | Japan 923-925 MHz (with EIRP cap according to Japanese regulations)|
 | `thethings.meshed.com.au`           | Australia 915-928 MHz                            |
 | `as923.thethings.meshed.com.au`     | Australia (Southeast Asia 923MHz frequency plan) |
-| `ttn.opennetworkinfrastructure.org` | Switzerland (EU 433 and EU 863-870)              |
+| `router.ch.onia.network`            | Switzerland (EU 433 and EU 863-870)              |
 
 ## Troubleshooting
 


### PR DESCRIPTION
As discussed over email, this is in preparation for the addition of the new domain for the Swiss zone.
The previous domain will stay functional for good, so, it's not a change but an addition, but the new one is much easiest to type and more in line with the naming of all other router domains.

**NOTE: Please do not merge until all the steps are ready to activate it.**