### PR TITLE
Kerlink configuration mention wiki

### DIFF
--- a/_content/gateways/kerlink/config.md
+++ b/_content/gateways/kerlink/config.md
@@ -5,6 +5,10 @@ zindex: 800
 
 # Configuration
 
+> If you bought one of these gateway directly from Kerlink, you can apply for access to the [Kerlink Wiki](http://wikikerlink.fr/lora-station) by sending an email to support@kerlink.fr mentioning the serial number of your gateway. 
+> 
+> If you have access to the Kerlink wiki it is recommended to follow the firmware upgrade and packet forwarder installation steps from there. This will ensure you are running the latest and most reliable version.
+
 ## Configuring packet forwarder
 
 To configure the gateway, you need to download either [The Things Network's packet forwarder (EU version)](https://github.com/TheThingsNetwork/kerlink-station-firmware/blob/master/dota/dota_thethingsnetwork_v1.3_EU.tar.gz) and [produsb.zip](https://github.com/TheThingsNetwork/kerlink-station-firmware/blob/master/dota/produsb.zip) from our Github.

--- a/_content/gateways/kerlink/config.md
+++ b/_content/gateways/kerlink/config.md
@@ -5,7 +5,7 @@ zindex: 800
 
 # Configuration
 
-> If you bought one of these gateway directly from Kerlink, you can apply for access to the [Kerlink Wiki](http://wikikerlink.fr/lora-station) by sending an email to support@kerlink.fr mentioning the serial number of your gateway. 
+> If you bought one of these gateways directly from Kerlink, you can apply for access to the [Kerlink Wiki](http://wikikerlink.fr/lora-station) by sending an email to support@kerlink.fr mentioning the serial number of your gateway. 
 > 
 > If you have access to the Kerlink wiki it is recommended to follow the firmware upgrade and packet forwarder installation steps from there. This will ensure you are running the latest and most reliable version.
 


### PR DESCRIPTION
Add a note about the Kerlink Wiki and that the latest official packet forwarder sources can be found there.

We should also update the dota that we host to rather use the official supported SPF or CPF from Kerlink. We can download theirs and update the network server addresses to be the TTN ones before we host it.