### PR TITLE
Fix URLs for Discovery Server

### DIFF
--- a/_content/network/discovery/index.md
+++ b/_content/network/discovery/index.md
@@ -13,4 +13,5 @@ The Discovery Server is the key to the decentralized architecture of The Things 
 Use the following endpoints for the community network:
 
 - [gRPC](http://www.grpc.io/): `discovery.thethingsnetwork.org:1900`
-- HTTP: `http://discovery.thethingsnetwork.org:8080`
+- HTTP: `http://discovery.thethingsnetwork.org`
+- HTTPS: `https://discovery.thethingsnetwork.org`


### PR DESCRIPTION
Trial and errors seems to show that the port 8080 is obsolete, as 80 works just fine too. Also, HTTPS seems to be supported on the default port 443.