### PR TITLE
Temporarily add warning for disabled uplink fields

### DIFF
--- a/_content/applications/mqtt/api.md
+++ b/_content/applications/mqtt/api.md
@@ -93,7 +93,7 @@ func main() {
 
 ### Uplink Fields
 
->**Warning**: subscribing to specific fields has been temporarily disabled for the EU region; see [the TTN Status Page](https://status.thethings.network/incidents/z25436h9zxwq) for details.
+> **Warning**: not every cluster publishes uplink fields to individual topics. See [status.thethings.network](https://status.thethings.network) for details.
 
 Each uplink field will be published to its own topic `my-app-id/devices/my-dev-id/up/<field>`. The payload will be a string with the value in a JSON-style encoding. 
 

--- a/_content/applications/mqtt/api.md
+++ b/_content/applications/mqtt/api.md
@@ -93,6 +93,8 @@ func main() {
 
 ### Uplink Fields
 
+>**Warning**: subscribing to specific fields has been temporarily disabled for the EU region; see [the TTN Status Page](https://status.thethings.network/incidents/z25436h9zxwq) for details.
+
 Each uplink field will be published to its own topic `my-app-id/devices/my-dev-id/up/<field>`. The payload will be a string with the value in a JSON-style encoding. 
 
 If your fields look like the following:

--- a/_content/applications/mqtt/quick-start.md
+++ b/_content/applications/mqtt/quick-start.md
@@ -69,7 +69,7 @@ Now let's listen for actual messages coming in from devices.
     
 ### Subscribe to a specific field
 
->**Warning**: subscribing to specific fields has been temporarily disabled for the EU region; see [the TTN Status Page](https://status.thethings.network/incidents/z25436h9zxwq) for details.
+> **Warning**: not every cluster publishes uplink fields to individual topics. See [status.thethings.network](https://status.thethings.network) for details.
 
 You can also subscribe to a specific field. Building on [The Things Uno / Quick Start](../../devices/uno/quick-start.md) you could subscribe to get just the `led` field:
 

--- a/_content/applications/mqtt/quick-start.md
+++ b/_content/applications/mqtt/quick-start.md
@@ -69,6 +69,8 @@ Now let's listen for actual messages coming in from devices.
     
 ### Subscribe to a specific field
 
+>**Warning**: subscribing to specific fields has been temporarily disabled for the EU region; see [the TTN Status Page](https://status.thethings.network/incidents/z25436h9zxwq) for details.
+
 You can also subscribe to a specific field. Building on [The Things Uno / Quick Start](../../devices/uno/quick-start.md) you could subscribe to get just the `led` field:
 
 ```bash


### PR DESCRIPTION
As per https://status.thethings.network/incidents/z25436h9zxwq to avoid problems such as https://www.thethingsnetwork.org/forum/t/i-cant-subscribe-to-mqtt-topic-referring-to-single-field/32448