### PR TITLE
Update on Argentina freq plan

### DIFF
--- a/_content/lorawan/frequencies-by-country.md
+++ b/_content/lorawan/frequencies-by-country.md
@@ -22,7 +22,7 @@ For discussions about the frequency plans in different countries, see the posts 
 | Andorra | EU863-870<br />EU433 | CEPT Rec. 70-03 |
 | Angola | EU863-870<br />EU433 | CRASA follows CEPT Rec. 70-03 |
 | Antigua and Barbuda | | |
-| Argentina | AU915-928 | RESOL-2018-581-APN-MM |
+| Argentina | AU915-928 | [RESOL-2018-581-APN-MM](https://www.enacom.gob.ar/multimedia/normativas/2018/res581MM.pdf) |
 | Armenia | | EN 302 208  |
 | Australia | AU915-928 | |
 | Austria | EU863-870<br />EU433 | CEPT Rec. 70-03 |

--- a/_content/lorawan/frequencies-by-country.md
+++ b/_content/lorawan/frequencies-by-country.md
@@ -22,7 +22,7 @@ For discussions about the frequency plans in different countries, see the posts 
 | Andorra | EU863-870<br />EU433 | CEPT Rec. 70-03 |
 | Angola | EU863-870<br />EU433 | CRASA follows CEPT Rec. 70-03 |
 | Antigua and Barbuda | | |
-| Argentina | US902-928 | |
+| Argentina | AU915-928 | RESOL-2018-581-APN-MM |
 | Armenia | | EN 302 208  |
 | Australia | AU915-928 | |
 | Austria | EU863-870<br />EU433 | CEPT Rec. 70-03 |


### PR DESCRIPTION
The frequency plan for Argentina is wrong on the website and this will lead to the deployment of non-compliant devices. Please see as a reference both the LoRa Alliance spec: https://lora-alliance.org/sites/default/files/2020-01/rp_2-1.0.0_final_release.pdf
Also, the ENACOM (Argentina's regulatory entity) with the available non-licensed bands states that 915-928 MHz only is available: https://www.enacom.gob.ar/multimedia/normativas/2018/res581MM.pdf

Thanks!