### PR TITLE
Add hint that Storage API will not return data unless there was traffic

### DIFF
--- a/_content/applications/storage/index.md
+++ b/_content/applications/storage/index.md
@@ -5,7 +5,7 @@ section: Integrations
 
 # Storage Integration
 
-The Storage Integration allows you to persist data in a database. The data is stored for seven days. You can then use the [API](api.md) to retrieve this data.
+The Storage Integration allows you to persist data in a database. The data is stored for seven days. You can then use the [API](api.md) to retrieve this data. Retrieving data will work as soon as the first data traffic happened after adding the integration.
 
 * [Add the Integration](../integrations.md#add-an-integration)
 * [Use the Integration](api.md)


### PR DESCRIPTION
After adding a Data Storage integration the ```GET /api/v2/devices endpoint``` returns ```204 No Content``` until a new data traffic happened. After that the API returns non-empty responses.