### PR TITLE
Add v3 docs note

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -26,7 +26,6 @@ layout: default
   <div class="container-fluid ttn-container">
 
     <div class="row page-top-nav">
-
       <div class="col-sm-9">
         <ul>
           <li class="page-top-nav-crumb"><a href="http://www.thethingsnetwork.org/">Home</a></li>
@@ -45,6 +44,11 @@ layout: default
       <div class="hidden-xs col-sm-3 text-right">
         <a href="{% if page.source %}{{ page.source }}{% else %}{{ site.github.repository_url }}/edit/master/{{ page.path | downcase }}{% endif %}" class="page-edit" data-proofer-ignore><i class="fa fa-github"></i> Edit <strong>{{ page.path | split:'/' | last }}</strong></a>
       </div>
+
+      <div class="col-12">
+        This documentation page applies to the legacy Things Network Stack V2. Documentation for The Things Stack V3 is available <a href="https://thethingsstack.io">here</a>
+      </div>
+
     </div>
 
     <div class="row wrapper">

--- a/index.html
+++ b/index.html
@@ -32,6 +32,12 @@ image: /assets/images/og-image.png
 
     <h2 class="index-title">Documentation</h2>
 
+    <h3 class="index-intro">
+      The Things Network is upgrading to The Things Stack! This documentation page applies to the legacy Things Network Stack V2.
+      <br>
+      Documentation for The Things Stack is available <a href="thethingsstack.io">here</a>.
+    </h3>
+
     <div class="index-docs index-blocks row">
 
       <div class="col-sm-12">


### PR DESCRIPTION
Closes #406. Draft to add a v2/v3 note to the TTN docs. @johanstokking can you give some feedback about the text? @GreenPenguino can you double check the HTML?

Looks like:

![localhost_4000_docs_devices_index html(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/6963436/97971405-434ed480-1dc3-11eb-86c8-74054780e60d.png)

And:

![localhost_4000_docs_(Laptop with HiDPI screen)](https://user-images.githubusercontent.com/6963436/97971413-477af200-1dc3-11eb-9e5a-9e0703a0154f.png)
