### PR TITLE
fix broken link to v3 stack documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ image: /assets/images/og-image.png
     <h3 class="index-intro">
       The Things Network is upgrading to The Things Stack! This documentation page applies to the legacy Things Network Stack V2.
       <br>
-      Documentation for The Things Stack is available <a href="thethingsstack.io">here</a>.
+      Documentation for The Things Stack is available <a href="https://thethingsstack.io">here</a>.
     </h3>
 
     <div class="index-docs index-blocks row">


### PR DESCRIPTION
The current url is a relative link and as a result points to https://www.thethingsnetwork.org/docs/thethingsstack.io, which is not a valid address.
By adding `https://` in front of the link it becomes an absolute url and points to https://thethingsstack.io