### PR TITLE
doc: TTS CE to to TTN V2 offloading

### DIFF
--- a/doc/content/the-things-stack/migrate-to-v3/_index.md
+++ b/doc/content/the-things-stack/migrate-to-v3/_index.md
@@ -7,6 +7,8 @@ aliases:
 
 This guide was written to explain the overall migration process of migrating from The Things Network V2 to The Things Stack Community Edition in a several easy-to-follow steps.
 
+{{< note >}} Since version 3.13 (released in May, 2021), The Things Network V2 routes traffic back and forth to The Things Stack Community Edition. When migrating your gateways to The Things Stack Community Edition, the coverage of the public community network won't be impacted. {{</ note >}}
+
 {{< info >}} 
 The Things Stack Community Edition is a LoRaWAN Network Server which is free to use for The Things Network community members. The Community Edition is designed for testing and evaluating LoRaWAN projects and is managed by <a href="https://www.thethingsindustries.com/" target="_blank">The Things Industries</a>. The Community Edition comes without guarantees and only includes community support, hence is not suitable for commercial usage. Join The Things Network [Forum](https://www.thethingsnetwork.org/forum/) or <a href="https://thethingsnetwork.slack.com/" target="_blank">Slack</a> for community support.
 
@@ -63,7 +65,4 @@ Depending on your use case, you might want to:
 
 - Keep your gateway connected to The Things Network V2 and route your traffic via Packet Broker to The Things Stack Community Edition - if this is the case, we recommend to read the <a href="https://www.thethingsindustries.com/docs/getting-started/migrating/migrating-from-v2/packet-broker-requirements/" target="_blank">Packet Broker Requirements</a>
 - Migrate your gateway to The Things Stack Community Edition - see [Migrate Gateways]({{< ref "/the-things-stack/migrate-to-v3/migrate-gateways" >}})
-
-{{< note >}} Since version 3.13 (released in May, 2021), The Things Network V2 routes traffic back and forth to The Things Stack Community Edition. When migrating your gateways to The Things Stack Community Edition, the coverage of the public community network won't be impacted. {{</ note >}}
-
 

--- a/doc/content/the-things-stack/migrate-to-v3/migrate-gateways.md
+++ b/doc/content/the-things-stack/migrate-to-v3/migrate-gateways.md
@@ -5,8 +5,6 @@ weight: 300
 
 This section shortly describes steps to be taken to migrate your gateway from The Things Network V2 to The Things Stack Community Edition.
 
-{{< warning >}} We strongly recommend The Things Network community members to keep their gateways registered on The Things Network V2 for as long as possible, or to agree on performing coordinated migration to The Things Stack, as this will ensure the community does not loose their LoRaWAN coverage. {{</ warning >}}
-
 <a href="https://www.thethingsindustries.com/docs/getting-started/migrating/gateway-migration/" target="_blank">Migrating your gateway</a> from The Things Network V2 to The Things Stack Community Edition cluster is a really easy process. 
 
 First, you need to <a href="https://www.thethingsindustries.com/docs/gateways/adding-gateways/" target="_blank">add a gateway to The Things Stack Community Edition</a>.

--- a/doc/content/the-things-stack/migrate-to-v3/migrate-using-console.md
+++ b/doc/content/the-things-stack/migrate-to-v3/migrate-using-console.md
@@ -7,6 +7,8 @@ This section explains steps for migrating end devices from The Things Network V2
 
 {{< note >}} Migrating active sessions using The Things Stack Community Edition Console is available since the latest update to V3.12. <a href="https://www.thethingsindustries.com/docs/getting-started/migrating/migrating-from-v2/" target="_blank">click here</a>.{{</ note >}}
 
+{{< note >}} Since version 3.13 (released in May, 2021), The Things Network V2 routes traffic back and forth to The Things Stack Community Edition. When migrating your gateways to The Things Stack Community Edition, the coverage of the public community network won't be impacted. {{</ note >}}
+
 ## Add an end device in The Things Stack Community Edition
 
 First, <a href="https://www.thethingsindustries.com/docs/devices/adding-devices/" target="_blank">add a device</a> in The Things Stack Community Edition. This can be done manually, but also by submitting the type of your device if it is available in the <a href="https://thethingsindustries.com/docs/integrations/payload-formatters/device-repo/" target="_blank">Device Repository</a>.
@@ -87,17 +89,11 @@ Since you have not migrated your gateway from The Things Network V2 yet, the new
 
 An interesting thing is that your OTAA end device's new Join request will be received by The Things Stack Community Edition cluster too! You can verify this by observing the uplinks metadata in The Things Stack Community Edition Console. You can thank for this to <a href="https://www.thethingsindustries.com/docs/reference/peering/#packet-broker" target="_blank">Packet Broker</a>, which routes your device's traffic from The Things Network V2 to The Things Stack Community Edition. Now, The Things Stack Community Edition cluster will accept this Join request, so your end device will get a new `DevAddr`, channel settings and other MAC parameters. Based on a newly assigned `DevAddr`, Packet Broker will from now on route the traffic to The Things Stack Community Edition network.
 
-{{< note >}} Even if you manage to get your OTAA end device traffic routed to The Things Stack Community Edition via Packet Broker, we still recommend you get in touch with your local The Things Network community and agree on coordinating the migration of gateways, so you do not lose the LoRaWAN network coverage. 
-
-See [Migrate Gateways]({{< ref "/the-things-stack/migrate-to-v3/migrate-gateways" >}}) for more info. {{</ note >}}
-
 ## What to do with ABP end device?
 
 The next step for ABP devices depends on your use case, which was previously discussed in the [Add an end device in The Things Stack Community Edition]({{< ref "/the-things-stack/migrate-to-v3/migrate-using-console#add-an-end-device-in-the-things-stack-community-edition" >}}) section. 
 
 If you re-programmed your ABP end device with a **DevAddr** issued by The Things Stack Community Edition and an **RX1 Delay** of 5 seconds, Packet Broker will be able to route your device's traffic to The Things Stack Community Edition, i.e. you will not have to migrate your gateway to receive the traffic in The Things Stack Community Edition. If this is the case, at this point you should already start seeing your device's traffic in The Things Stack Community Edition Console. 
-
-{{< note >}} Even if you manage to get your ABP end device traffic routed to The Things Stack Community Edition via Packet Broker, we still recommend you get in touch with your local The Things Network community and agree on coordinating the migration of gateways, so you do not lose the LoRaWAN network coverage. {{</ note >}}
 
 If you have not re-programmed your device, i.e. it is using the **DevAddr** and the **RX1 Delay** from The Things Network V2, you will have to migrate your gateway to The Things Stack Community Edition, because Packet Broker will not be able to route its traffic properly. 
 

--- a/doc/content/the-things-stack/migrate-to-v3/migrate-using-migration-tool.md
+++ b/doc/content/the-things-stack/migrate-to-v3/migrate-using-migration-tool.md
@@ -21,7 +21,7 @@ Theoretically, it is possible to migrate active sessions from The Things Network
 
 Migrating active sessions via Packet Broker is available only for The Things Industries V2 (V2 SaaS) customers migrating to The Things Stack Cloud, and exclusively on a customer request. {{</ warning >}}
 
-{{< note >}} Since migrating active sessions from The Things Network V2 to The Things Stack Community Edition is not a recommended practice in general, and not achievable via Packet Broker, we continue this guide with the steps for migrating your end devices without active sessions using `ttn-lw-migrate` tool. {{</ note >}}
+{{< note >}} Since migrating active sessions from The Things Network V2 to The Things Stack Community Edition is not a recommended practice in general, and not achievable via Packet Broker, we continue this guide with the steps for migrating your end devices without active sessions using `ttn-lw-migrate` tool. For more information on migration with existing session, <a href="https://www.thethingsindustries.com/docs/getting-started/migrating/migrating-from-v2/" target="_blank">click here</a>.{{</ note >}}
 
 For OTAA devices, migrating without an active session simply means that the device will establish a new session with The Things Stack Community Edition Network Server. The device will be assigned with a new **DevAddr** and an **RX1 Delay** of 5 seconds, which will ensure that the traffic can be properly routed via Packet Broker and that it will reach The Things Stack Community Edition in time.
 
@@ -141,10 +141,6 @@ How to do this largely depends on your device's firmware:
 Since you have not migrated your gateway from The Things Network V2 yet, the new Join request sent by your end device will be received by The Things Network V2 cluster. However, this request will not be accepted if you changed your end device's `AppKey` (as recommended above) or if you have deleted it.
 
 An interesting thing is that your OTAA end device's new Join request will be received by The Things Stack Community Edition cluster too! You can verify this by observing the uplinks metadata in The Things Stack Community Edition Console. You can thank for this to <a href="https://www.thethingsindustries.com/docs/reference/peering/#packet-broker" target="_blank">Packet Broker</a>, which routes your device's traffic from The Things Network V2 to The Things Stack Community Edition. Now, The Things Stack Community Edition cluster will accept this Join request, so your end device will get a new `DevAddr`, channel settings and other MAC parameters. Based on a newly assigned `DevAddr`, Packet Broker will from now on route the traffic to The Things Stack Community Edition network.
-
-{{< note >}} Even if you manage to get your OTAA end device traffic routed to The Things Stack Community Edition via Packet Broker, we still recommend you get in touch with your local The Things Network community and agree on coordinating the migration of gateways, so you do not lose the LoRaWAN network coverage. 
-
-See [Migrate Gateways]({{< ref "/the-things-stack/migrate-to-v3/migrate-gateways" >}}) for more info. {{</ note >}}
 
 ## What to do with ABP end device?
 


### PR DESCRIPTION
#### Summary
Update info to reflect the latest Packet Broker update (v3.13) where TTS Community Edition offloads traffic to TTN V2