### PR TITLE
Update header and footer scripts

### DIFF
--- a/doc/layouts/_default/baseof.html
+++ b/doc/layouts/_default/baseof.html
@@ -14,8 +14,8 @@
 
 <script src="https://cdn.jsdelivr.net/npm/promise-polyfill@7/dist/polyfill.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
-<script src="https://www.thethingsnetwork.org/static/common/js/ttn-header/index.js"></script>
-<script src="https://www.thethingsnetwork.org/static/common/js/ttn-footer/index.js"></script>
+<script src="https://www.thethingsnetwork.org/static/common/js/web-components/ttn-header.js"></script>
+<script src="https://www.thethingsnetwork.org/static/common/js/web-components/ttn-footer.js"></script>
 <script src="https://ttnweb.azureedge.net/static/common/js/ga.js"></script>
 
 {{- $script := resources.Get "js/vendor/basicLightbox.min.js" }}


### PR DESCRIPTION
Quickfix due to updated scripts for `ttn-header` and `ttn-footer`.

Current situation:

<img width="1916" alt="Screenshot 2021-09-08 at 2 56 07 PM" src="https://user-images.githubusercontent.com/19795814/132513154-04ac16e9-ebd8-4586-bd35-efede552bc6b.png">

