### PR TITLE
doc: Add V2 warning to all V2 docs

### DIFF
--- a/doc/layouts/partials/header/breadcrumb-container.html
+++ b/doc/layouts/partials/header/breadcrumb-container.html
@@ -33,6 +33,11 @@
       {{ end }}
       </ul>
     </nav>
+    {{ if (in $v2 .Section) }}
+      <div class="notification is-warning is-light has-text-dark">
+        <h5 class="title is-family-sans-serif has-text-dark mb-1">Warning:</h5>
+        This section contains documentation written for The Things Network V2, which is no longer maintained. See <a href="https://thethingsindustries.com/docs">documentation for The Things Stack V3</a>.
+      </div>
+    {{ end }}
   </div>
 </section>
-


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add warning to all V2 docs that V2 is outdated.

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

<img width="1235" alt="Bildschirmfoto 2021-09-28 um 15 46 38" src="https://user-images.githubusercontent.com/6963436/135089929-1f7dd5e4-9ba9-4a64-b6f2-5f157da20fc4.png">

#### Changes

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [x] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [x] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
