### PR TITLE
Fix Message Integrity Code calculation key in join-request (1.1)

### DIFF
--- a/doc/content/lorawan/message-types/index.md
+++ b/doc/content/lorawan/message-types/index.md
@@ -446,7 +446,7 @@ The following table presents which key is used to calculate the MIC of each mess
    </td>
    <td>Join-request
    </td>
-   <td>NwkSKey
+   <td>NwkKey
    </td>
   </tr>
   <tr>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixed Message Integrity Code calculation key in join-request for LoRaWAN 1.1

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![image](https://user-images.githubusercontent.com/36432168/137838706-58b5b588-58ab-41fe-bf16-91d4e2f6e929.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- Replaced NwkSKey with NwkKey
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@benolayinka I missed this in the previous review/PR.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
