### PR TITLE
Upgrade dependencies of Github Actions workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,12 +5,12 @@ on: pull_request
 jobs:
   build:
     name: Build docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Check out code
       uses: actions/checkout@v2
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '~1.17'
     - name: Get Go module cache directory path
@@ -26,9 +26,9 @@ jobs:
     - name: Download Go dependencies
       run: make go.deps
     - name: Set up Node
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
-        node-version: '~14'
+        node-version: '~16'
     - name: Get Yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(npx yarn cache dir)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,14 +8,14 @@ on:
 jobs:
   release:
     name: Release docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Check out code
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: '~1.17'
     - name: Get Go module cache directory path
@@ -31,9 +31,9 @@ jobs:
     - name: Download Go dependencies
       run: make go.deps
     - name: Set up Node
-      uses: actions/setup-node@v2-beta
+      uses: actions/setup-node@v3
       with:
-        node-version: '~14'
+        node-version: '~16'
     - name: Get Yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(npx yarn cache dir)"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This upgrades the dependencies of our Github Actions workflows

#### Changes
<!-- What are the changes made in this pull request? -->

- Upgrade `runs-on` from `ubuntu-18.04` to `ubuntu-20.04`
- Upgrade `actions/setup-go` from `v2` to `v3`
- Upgrade `actions/setup-node` from `v2` to `v3`
	- And upgraded `node-version` from `~14` to `~16`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil