### PR TITLE
Upgrade TTUI to 1.3.1

### DIFF
--- a/doc/layouts/partials/head/head.html
+++ b/doc/layouts/partials/head/head.html
@@ -45,7 +45,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
   {{- end }}
 
-  <link rel="stylesheet" href="https://ttui.thethingsindustries.com/release/1.0.0/main.css" />
+  <link rel="stylesheet" href="https://ttui.thethingsindustries.com/release/1.3.1/main.css" />
 
   {{ template "_internal/opengraph.html" . }}
 

--- a/doc/package.json
+++ b/doc/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Hugo Theme for The Things Stack",
   "dependencies": {
-    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.0.0.tar.gz",
+    "@tti/design": "https://ttui.thethingsindustries.com/release/ttui-1.3.1.tar.gz",
     "bulma": "^0.9.1"
   },
   "devDependencies": {}

--- a/doc/yarn.lock
+++ b/doc/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.0.0.tar.gz":
+"@tti/design@https://ttui.thethingsindustries.com/release/ttui-1.3.1.tar.gz":
   version "0.0.0"
-  resolved "https://ttui.thethingsindustries.com/release/ttui-1.0.0.tar.gz#b6f5a208b5854b1b63deaed7b1ac9f70217558ab"
+  resolved "https://ttui.thethingsindustries.com/release/ttui-1.3.1.tar.gz#c90d5483468d7a18d615a1b44b90a54c03371b82"
 
 bulma@^0.9.1:
   version "0.9.4"


### PR DESCRIPTION
#### Summary
Upgrade to TTUI v1.3.1

#### Screenshots
##### Before
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/48737089/217261208-adf71eb0-84ca-48ca-a6f8-d60e3e991753.png">

##### After
<img width="1798" alt="image" src="https://user-images.githubusercontent.com/48737089/217261368-349b261e-041d-4c6e-970a-3e0d698d78ef.png">


#### Changes
- Upgrade TTUI from v1.0.0 to v1.3.1

#### Notes for Reviewers
~I believe this upgrade somehow removes the padding/margin left of the logo and right of the log in button.~ 
@kschiffer @mjamescompton Is this intentional and do you have any suggestions?

This is now fixed after applying the changes by @mjamescompton.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
