### PR TITLE
doc: Update EU sub-bands and duty cycles

### DIFF
--- a/doc/content/lorawan/duty-cycle/_index.md
+++ b/doc/content/lorawan/duty-cycle/_index.md
@@ -19,15 +19,16 @@ In our European frequency plan, we have channels in different _sub-bands_, so wh
 
 The duty cycle of radio devices is often regulated by government. If this is the case, the duty cycle is commonly set to 1%, but make sure to check the regulations of your local government to be sure.
 
-In Europe, duty cycles are regulated by section 7.2.3 of the ETSI EN300.220 standard. This standard defines the following sub-bands and their duty cycles:
+In Europe, duty cycles are regulated by section 4.3.3 of the [ETSI EN300.220-2 V3.2.1 (2018-06)](https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf) standard. This standard defines the following sub-bands and their duty cycles:
 
-* **g** (863.0 – 868.0 MHz): 1%
-* **g1** (868.0 – 868.6 MHz): 1%
-* **g2** (868.7 – 869.2 MHz): 0.1%
-* **g3** (869.4 – 869.65 MHz): 10%
-* **g4** (869.7 – 870.0 MHz): 1%
+- **K** (863 MHz - 865 MHz): 0.1%
+- **L** (865 MHz - 868 MHz): 1%
+- **M** (868 MHz - 868.6 MHz): 1%
+- **N** (868.7 MHz - 869.2 MHz): 0.1%
+- **P** (869.4 MHz - 869.65 MHz): 10%
+- **Q** (869.7 MHz - 870 MHz): 1%
 
-Additionally, the LoRaWAN specification dictates duty cycles for the _join frequencies_, the frequencies devices of all LoRaWAN-compliant networks use for over-the-air activations (OTAA) of devices. In most regions this duty cycle is set to **1%**.
+Additionally, The LoRaWAN specification specifies duty cycles for the join frequencies, which are used for over-the-air activations (OTAA) by every end device. In most regions, the duty cycle for these frequencies is set to **1%**.
 
 #### Fair Use Policy
 On The Things Network's public community network a **Fair Use Policy** applies which limits the **uplink airtime** to **30 seconds per day (24 hours) per node** and the **downlink messages** to **10 messages per day (24 hours) per node**. If you use a private network, these limits do not apply, but you still have to be compliant with the governmental and LoRaWAN limits.

--- a/doc/content/lorawan/duty-cycle/_index.md
+++ b/doc/content/lorawan/duty-cycle/_index.md
@@ -28,7 +28,7 @@ In Europe, duty cycles are regulated by section 4.3.3 of the [ETSI EN300.220-2 V
 - **P** (869.4 MHz - 869.65 MHz): 10%
 - **Q** (869.7 MHz - 870 MHz): 1%
 
-Additionally, The LoRaWAN specification specifies duty cycles for the join frequencies, which are used for over-the-air activations (OTAA) by every end device. In most regions, the duty cycle for these frequencies is set to **1%**.
+Additionally, the LoRaWAN specification specifies duty cycles for the join frequencies, which are used for over-the-air activations (OTAA) by every LoRaWAN-compliant end device. In most regions, the duty cycle for these frequencies is set to **1%**.
 
 #### Fair Use Policy
 On The Things Network's public community network a **Fair Use Policy** applies which limits the **uplink airtime** to **30 seconds per day (24 hours) per node** and the **downlink messages** to **10 messages per day (24 hours) per node**. If you use a private network, these limits do not apply, but you still have to be compliant with the governmental and LoRaWAN limits.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Updated EU sub-bands and duty cycles section 4.3.3 of the [ETSI EN300.220-2 V3.2.1 (2018-06)](https://www.etsi.org/deliver/etsi_en/300200_300299/30022002/03.02.01_60/en_30022002v030201p.pdf) standard.

Related to the issue: https://github.com/TheThingsNetwork/docs/issues/507

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

![image](https://user-images.githubusercontent.com/36432168/235693143-71a21afe-4281-4a98-b5d0-21210d6542b2.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- Replaced old g-g4 sub-bands with new K-Q sub-bands as specified in the ETSI EN300.220-2 V3.2.1 (2018-06).
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [X] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [X] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
